### PR TITLE
[FEAT] Add custom data URL support

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,10 @@
       "DARK_SHOW_BORDER",
       "VIBRATE_ON_DISCONNECT",
       "LIGHT_BG_COLOR",
-      "DARK_BG_COLOR"
+      "DARK_BG_COLOR",
+      "CUSTOM_URL",
+      "CUSTOM_DATA",
+      "CUSTOM_URL_REQUEST"
     ],
     "resources": {
       "media": [

--- a/src/c/config.c
+++ b/src/c/config.c
@@ -1,5 +1,6 @@
 #include <pebble.h>
 #include "config.h"
+#include "custom_url.h"
 
 int s_color_theme = 0; // 0 = dark, 1 = light, 2 = auto day/night, 3 = auto quiet time
 int s_step_goal = 10000;
@@ -293,5 +294,19 @@ void load_vibrate_on_disconnect_from_storage() {
   } else {
     s_vibrate_on_disconnect = 0; // Default to disabled
     APP_LOG(APP_LOG_LEVEL_DEBUG, "No vibrate on disconnect preference found, using default disabled");
+  }
+}
+
+void save_custom_data_to_storage() {
+  persist_write_string(PERSIST_KEY_CUSTOM_DATA, s_custom_data);
+  APP_LOG(APP_LOG_LEVEL_DEBUG, "Saved custom data to storage: %s", s_custom_data);
+}
+
+void load_custom_data_from_storage() {
+  if (persist_exists(PERSIST_KEY_CUSTOM_DATA)) {
+    persist_read_string(PERSIST_KEY_CUSTOM_DATA, s_custom_data, sizeof(s_custom_data));
+    APP_LOG(APP_LOG_LEVEL_DEBUG, "Loaded custom data from storage: %s", s_custom_data);
+  } else {
+    APP_LOG(APP_LOG_LEVEL_DEBUG, "No custom data found in storage, using default");
   }
 }

--- a/src/c/config.h
+++ b/src/c/config.h
@@ -33,6 +33,7 @@
 #define PERSIST_KEY_VIBRATE_ON_DISCONNECT 26
 #define PERSIST_KEY_LIGHT_BG_COLOR 27
 #define PERSIST_KEY_DARK_BG_COLOR 28
+#define PERSIST_KEY_CUSTOM_DATA 29
 
 // Layer position and alignment enums
 typedef enum {
@@ -72,7 +73,8 @@ typedef enum {
   INFO_TYPE_NONE = 5,
   INFO_TYPE_CALENDAR = 6,
   INFO_TYPE_DISCONNECT = 7,
-  INFO_TYPE_HEART_RATE = 8
+  INFO_TYPE_HEART_RATE = 8,
+  INFO_TYPE_CUSTOM_URL = 9
 } InfoType;
 
 // Current layer assignments (can be changed dynamically)
@@ -100,6 +102,7 @@ extern int s_dark_show_border; // 1 = show border in dark theme, 0 = hide
 extern int s_vibrate_on_disconnect; // 1 = vibrate on connect/disconnect, 0 = disabled
 extern int s_light_bg_color; // Background color for light theme as 0xRRGGBB
 extern int s_dark_bg_color; // Background color for dark theme as 0xRRGGBB
+extern char s_custom_data[33]; // Last value fetched from the user-configured URL
 
 /*
  * Function Declarations
@@ -132,6 +135,8 @@ void save_vibrate_on_disconnect_to_storage();
 void load_vibrate_on_disconnect_from_storage();
 void save_bg_colors_to_storage();
 void load_bg_colors_from_storage();
+void save_custom_data_to_storage();
+void load_custom_data_from_storage();
 bool is_dark_theme();
 bool is_light_theme();
 GColor get_background_color();

--- a/src/c/custom_url.c
+++ b/src/c/custom_url.c
@@ -1,0 +1,102 @@
+#include "custom_url.h"
+#include <string.h>
+
+char s_custom_data[33] = "N/A";
+bool s_custom_data_stale = false;
+
+// Parsed line buffers used by draw_custom_url_info (must persist after the function returns)
+static char s_line1[33];
+static char s_line2[33];
+
+bool request_custom_url_update() {
+  APP_LOG(APP_LOG_LEVEL_DEBUG, "Requesting custom URL update");
+
+  DictionaryIterator *iter;
+  AppMessageResult result = app_message_outbox_begin(&iter);
+
+  if (result != APP_MSG_OK || iter == NULL) {
+    APP_LOG(APP_LOG_LEVEL_WARNING, "Outbox busy (result=%d), custom URL request not sent", (int)result);
+    return false;
+  }
+
+  dict_write_uint8(iter, MESSAGE_KEY_CUSTOM_URL_REQUEST, 1);
+  app_message_outbox_send();
+  return true;
+}
+
+void draw_custom_url_info(InfoLayer* info_layer) {
+  GRect bounds = info_layer->bounds;
+  Layer* layer = info_layer->layer;
+  GColor stale_color = is_dark_theme() ? GColorYellow : GColorRed;
+  GColor text_color = s_custom_data_stale ? PBL_IF_COLOR_ELSE(stale_color, get_text_color()) : get_text_color();
+
+  // Split on "||" if present
+  const char *sep = strstr(s_custom_data, "||");
+  bool two_lines = (sep != NULL);
+
+  if (two_lines) {
+    int len1 = sep - s_custom_data;
+    if (len1 >= (int)sizeof(s_line1)) len1 = sizeof(s_line1) - 1;
+    strncpy(s_line1, s_custom_data, len1);
+    s_line1[len1] = '\0';
+    snprintf(s_line2, sizeof(s_line2), "%s", sep + 2);
+  } else {
+    snprintf(s_line1, sizeof(s_line1), "%s", s_custom_data);
+    s_line2[0] = '\0';
+  }
+
+  int y_center = bounds.size.h / 2 - 10;
+
+  if (two_lines) {
+    // Line 1 — bigger font (matches temperature line)
+#if defined(PBL_PLATFORM_EMERY)
+    GRect line1_frame = GRect(0, y_center - 16, bounds.size.w, 28);
+#else
+    GRect line1_frame = GRect(0, y_center - 14, bounds.size.w, 24);
+#endif
+    info_layer->text_layer1 = text_layer_create(line1_frame);
+    text_layer_set_background_color(info_layer->text_layer1, GColorClear);
+    text_layer_set_text_color(info_layer->text_layer1, text_color);
+    text_layer_set_text(info_layer->text_layer1, s_line1);
+#if defined(PBL_PLATFORM_EMERY)
+    text_layer_set_font(info_layer->text_layer1, fonts_get_system_font(FONT_KEY_GOTHIC_28_BOLD));
+#else
+    text_layer_set_font(info_layer->text_layer1, fonts_get_system_font(FONT_KEY_GOTHIC_24_BOLD));
+#endif
+    text_layer_set_text_alignment(info_layer->text_layer1, GTextAlignmentCenter);
+    layer_add_child(layer, text_layer_get_layer(info_layer->text_layer1));
+
+    // Line 2 — smaller font (matches location line)
+#if defined(PBL_PLATFORM_EMERY)
+    GRect line2_frame = GRect(0, y_center + 12, bounds.size.w, 24);
+#else
+    GRect line2_frame = GRect(0, y_center + 8, bounds.size.w, 18);
+#endif
+    info_layer->text_layer2 = text_layer_create(line2_frame);
+    text_layer_set_background_color(info_layer->text_layer2, GColorClear);
+    text_layer_set_text_color(info_layer->text_layer2, text_color);
+    text_layer_set_text(info_layer->text_layer2, s_line2);
+#if defined(PBL_PLATFORM_EMERY)
+    text_layer_set_font(info_layer->text_layer2, fonts_get_system_font(FONT_KEY_GOTHIC_18));
+#else
+    text_layer_set_font(info_layer->text_layer2, fonts_get_system_font(FONT_KEY_GOTHIC_14));
+#endif
+    text_layer_set_text_alignment(info_layer->text_layer2, GTextAlignmentCenter);
+    layer_add_child(layer, text_layer_get_layer(info_layer->text_layer2));
+
+  } else {
+    // Single line — centered in the panel
+    info_layer->text_layer1 = text_layer_create(GRect(0, 0, bounds.size.w, bounds.size.h));
+    text_layer_set_background_color(info_layer->text_layer1, GColorClear);
+    text_layer_set_text_color(info_layer->text_layer1, text_color);
+    text_layer_set_text(info_layer->text_layer1, s_line1);
+#if defined(PBL_PLATFORM_EMERY)
+    text_layer_set_font(info_layer->text_layer1, fonts_get_system_font(FONT_KEY_GOTHIC_18_BOLD));
+#else
+    text_layer_set_font(info_layer->text_layer1, fonts_get_system_font(FONT_KEY_GOTHIC_14_BOLD));
+#endif
+    text_layer_set_text_alignment(info_layer->text_layer1, GTextAlignmentCenter);
+    text_layer_set_overflow_mode(info_layer->text_layer1, GTextOverflowModeWordWrap);
+    layer_add_child(layer, text_layer_get_layer(info_layer->text_layer1));
+  }
+}

--- a/src/c/custom_url.h
+++ b/src/c/custom_url.h
@@ -1,0 +1,16 @@
+#ifndef CUSTOM_URL_H
+#define CUSTOM_URL_H
+
+#include <pebble.h>
+#include "config.h"
+
+// Buffer holding the last value fetched from the user-configured URL.
+// Max 32 displayable characters (plus null terminator).
+extern char s_custom_data[33];
+// True when all retry attempts were exhausted and no fresh data was received.
+extern bool s_custom_data_stale;
+
+void draw_custom_url_info(InfoLayer* info_layer);
+bool request_custom_url_update(); // returns true if message was sent, false if outbox was busy
+
+#endif // CUSTOM_URL_H

--- a/src/c/pebble-mesh.c
+++ b/src/c/pebble-mesh.c
@@ -8,6 +8,7 @@
 #include "disconnect.h"
 #include "heart_rate.h"
 #include "weather_forecast.h"
+#include "custom_url.h"
 
 
 
@@ -59,6 +60,7 @@ static void draw_time(Layer *layer, GContext *ctx);
 static void draw_date(Layer *layer, GContext *ctx);
 static void inbox_received_callback(DictionaryIterator *iterator, void *context);
 static void delayed_weather_request(void *data);
+static void delayed_custom_url_request(void *data);
 static void init_info_layers(GRect bounds);
 static void update_all_info_layers();
 static void draw_info_for_type(InfoType info_type, InfoLayer* info_layer);
@@ -318,6 +320,16 @@ static void inbox_received_callback(DictionaryIterator *iterator, void *context)
     save_bg_colors_to_storage();
     APP_LOG(APP_LOG_LEVEL_DEBUG, "Background colors changed to: %x / %x", s_light_bg_color, s_dark_bg_color);
     update_colors();
+  }
+
+  // Read custom URL data value
+  Tuple *custom_data_tuple = dict_find(iterator, MESSAGE_KEY_CUSTOM_DATA);
+  if (custom_data_tuple) {
+    snprintf(s_custom_data, sizeof(s_custom_data), "%s", custom_data_tuple->value->cstring);
+    s_custom_data_stale = false;
+    save_custom_data_to_storage();
+    APP_LOG(APP_LOG_LEVEL_DEBUG, "Custom data updated: %s", s_custom_data);
+    update_all_info_layers();
   }
 
   // Read disconnect position
@@ -802,6 +814,9 @@ static void draw_info_for_type(InfoType info_type, InfoLayer* info_layer) {
     case INFO_TYPE_HEART_RATE:
       draw_heart_rate_info(info_layer);
       break;
+    case INFO_TYPE_CUSTOM_URL:
+      draw_custom_url_info(info_layer);
+      break;
     case INFO_TYPE_COLORED_BOX:
       draw_colored_box_info(info_layer);
       break;
@@ -934,6 +949,32 @@ static void delayed_weather_request(void *data) {
   request_weather_update();
 }
 
+// Retry counter for delayed_custom_url_request — file-level so main_window_appear can reset it.
+static int s_custom_url_retries = 0;
+
+#define CUSTOM_URL_MAX_RETRIES 8
+#define CUSTOM_URL_RETRY_INTERVAL_MS 1500
+
+// Timer callback to request custom URL data after UI is loaded.
+// Retries several times if the outbox is still busy (e.g. weather request in flight).
+// The outbox can only hold one unacknowledged outgoing message at a time, so this only
+// fails transiently while another message (weather, config, ...) is still being delivered.
+static void delayed_custom_url_request(void *data) {
+  APP_LOG(APP_LOG_LEVEL_DEBUG, "Requesting custom URL update (delayed, attempt %d)", s_custom_url_retries + 1);
+  if (!request_custom_url_update()) {
+    if (++s_custom_url_retries < CUSTOM_URL_MAX_RETRIES) {
+      app_timer_register(CUSTOM_URL_RETRY_INTERVAL_MS, delayed_custom_url_request, NULL);
+    } else {
+      APP_LOG(APP_LOG_LEVEL_WARNING, "Custom URL request gave up after %d attempts", CUSTOM_URL_MAX_RETRIES);
+      s_custom_data_stale = true;
+      update_all_info_layers();
+      s_custom_url_retries = 0;
+    }
+  } else {
+    s_custom_url_retries = 0;
+  }
+}
+
 // Initialize the 4 info layers with proper positioning
 static void init_info_layers(GRect bounds) {
 
@@ -1005,6 +1046,13 @@ static void main_window_appear(Window *window) {
 
   // Request weather update after a short delay to prevent blocking UI
   app_timer_register(100, delayed_weather_request, NULL);
+  // Request custom URL update separately, staggered well after the weather request so it
+  // doesn't immediately collide with it for the single-slot outbox (which only holds one
+  // unacknowledged outgoing message at a time). Reset stale state and retry counter so a
+  // fresh window appearance never inherits red text from a previous retry cycle.
+  s_custom_data_stale = false;
+  s_custom_url_retries = 0;
+  app_timer_register(1500, delayed_custom_url_request, NULL);
 }
 
 static void main_window_load(Window *window) {
@@ -1150,6 +1198,7 @@ static void init() {
   load_dark_show_border_from_storage();
   load_vibrate_on_disconnect_from_storage();
   load_bg_colors_from_storage();
+  load_custom_data_from_storage();
 
   s_last_was_dark = is_dark_theme();
 

--- a/src/pkjs/config.js
+++ b/src/pkjs/config.js
@@ -149,6 +149,7 @@ module.exports = [
           { "label": "Heart Rate", "value": "8" },
           { "label": "Battery", "value": "3" },
           { "label": "Calendar", "value": "6" },
+          { "label": "Custom Data", "value": "9" },
           { "label": "None", "value": "5" }
         ]
       },
@@ -164,6 +165,7 @@ module.exports = [
           { "label": "Heart Rate", "value": "8" },
           { "label": "Battery", "value": "3" },
           { "label": "Calendar", "value": "6" },
+          { "label": "Custom Data", "value": "9" },
           { "label": "None", "value": "5" }
         ]
       },
@@ -179,6 +181,7 @@ module.exports = [
           { "label": "Heart Rate", "value": "8" },
           { "label": "Battery", "value": "3" },
           { "label": "Calendar", "value": "6" },
+          { "label": "Custom Data", "value": "9" },
           { "label": "None", "value": "5" }
         ]
       },
@@ -194,6 +197,7 @@ module.exports = [
           { "label": "Heart Rate", "value": "8" },
           { "label": "Battery", "value": "3" },
           { "label": "Calendar", "value": "6" },
+          { "label": "Custom Data", "value": "9" },
           { "label": "None", "value": "5" }
         ]
       },
@@ -293,6 +297,25 @@ module.exports = [
           { "label": "30 seconds", "value": "4" },
           { "label": "Until dismissed", "value": "2" }
         ]
+      }
+    ]
+  },
+  {
+    "type": "section",
+    "items": [
+      {
+        "type": "heading",
+        "defaultValue": "Custom Data"
+      },
+      {
+        "type": "input",
+        "messageKey": "CUSTOM_URL",
+        "label": "Custom Data URL",
+        "defaultValue": "",
+        "description": "Enter an HTTPS URL that returns a short plain-text value (max 32 characters shown). Fetched every 30 minutes. Example: a URL that returns your server's uptime or a custom sensor reading. Use || to split into two lines: the text before || is shown in a large font and the text after || in a smaller font (e.g. '25°C||Vienna').",
+        "attributes": {
+          "placeholder": "https://example.com/data.txt"
+        }
       }
     ]
   },

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -22,7 +22,8 @@ var config = {
   darkShowBorder: true, // Show border in dark theme
   vibrateOnDisconnect: false, // Vibrate on connect/disconnect
   lightBgColor: 0xFFFFFF, // Background color for light theme
-  darkBgColor: 0x000000 // Background color for dark theme
+  darkBgColor: 0x000000, // Background color for dark theme
+  customUrl: '' // URL to fetch custom data from
 };
 
 // Clay's color picker sends an int, the BW select sends a hex string
@@ -87,6 +88,9 @@ if (localStorage.getItem('LIGHT_BG_COLOR') !== null) {
 }
 if (localStorage.getItem('DARK_BG_COLOR') !== null) {
   config.darkBgColor = parseInt(localStorage.getItem('DARK_BG_COLOR'), 10);
+}
+if (localStorage.getItem('CUSTOM_URL') !== null) {
+  config.customUrl = localStorage.getItem('CUSTOM_URL');
 }
 
 // Variables to store weather data
@@ -168,6 +172,11 @@ function getCoordinatesForCityAndFetchWeather(cityName) {
     weatherData.condition = -1;
   };
   xhr.send();
+}
+
+function isCustomDataNeeded() {
+  return [config.layoutUpperLeft, config.layoutUpperRight, config.layoutLowerLeft, config.layoutLowerRight]
+    .some(function(v) { return v === 9; });
 }
 
 // Main function to fetch weather for configured location
@@ -421,6 +430,52 @@ function getWeatherData(latitude, longitude) {
 }
 
 
+// Fetch data from the user-configured custom URL and send it to the watch
+function fetchCustomUrl() {
+  if (!config.customUrl || config.customUrl.trim() === '') {
+    console.log('No custom URL configured, skipping fetch');
+    return;
+  }
+
+  var url = config.customUrl.trim();
+
+  // Only allow https:// URLs to prevent plain-text traffic
+  if (url.indexOf('https://') !== 0) {
+    console.log('Custom URL must use HTTPS, skipping: ' + url);
+    enqueueMessage('custom_data', { 'CUSTOM_DATA': 'HTTPS only' });
+    return;
+  }
+
+  console.log('Fetching custom URL: ' + url);
+
+  var xhr = new XMLHttpRequest();
+  xhr.onreadystatechange = function() {
+    if (xhr.readyState === 4) {
+      if (xhr.status === 200) {
+        // Use the raw response text, trimmed and capped at 32 characters
+        var text = (xhr.responseText || '').trim().substring(0, 32);
+        console.log('Custom URL response: ' + text);
+        enqueueMessage('custom_data', { 'CUSTOM_DATA': text });
+      } else {
+        // Transient failure - keep showing the last known-good value on the watch
+        // instead of overwriting it with an error string (same approach as weather).
+        console.log('Custom URL request failed with status: ' + xhr.status + ', keeping last known value');
+      }
+    }
+  };
+
+  xhr.open('GET', url, true);
+  xhr.timeout = 10000;
+  xhr.ontimeout = function() {
+    console.log('Custom URL request timed out, keeping last known value');
+  };
+  xhr.onerror = function() {
+    console.log('Custom URL request network error, keeping last known value');
+  };
+  xhr.send();
+}
+
+
 function colorThemeStrToInt(themeStr) {
   if (themeStr === 'light') {
     return 1;
@@ -533,6 +588,16 @@ Pebble.addEventListener('appmessage', function(e) {
     console.log('Weather update requested from watch');
     fetchWeatherForLocation();
   }
+
+  // Check if it's a custom URL update request
+  if (e.payload.CUSTOM_URL_REQUEST) {
+    if (isCustomDataNeeded()) {
+      console.log('Custom URL update requested from watch');
+      fetchCustomUrl();
+    } else {
+      console.log('Custom URL update requested but no custom data slot configured, skipping');
+    }
+  }
   
   // Check if it's a location configuration update
   if (e.payload.WEATHER_LOCATION_CONFIG) {
@@ -639,6 +704,13 @@ Pebble.addEventListener('webviewclosed', function(e) {
     layoutChanged = true;
   }
 
+  if (dict.CUSTOM_URL !== undefined) {
+    config.customUrl = dict.CUSTOM_URL.value || '';
+    localStorage.setItem('CUSTOM_URL', config.customUrl);
+    console.log('Custom URL saved to: ' + config.customUrl);
+    if (isCustomDataNeeded()) fetchCustomUrl();
+  }
+
   if (dict.DATE_FORMAT !== undefined) {
     config.dateFormat = dict.DATE_FORMAT.value || ' %a %d';
     localStorage.setItem('DATE_FORMAT', config.dateFormat);
@@ -687,18 +759,19 @@ Pebble.addEventListener('webviewclosed', function(e) {
 
 });
 
-// Update weather every 30 minutes
+// Update weather/custom data every 30 minutes
 setInterval(function() {
-  console.log('Periodic weather update (30min timer) for: ' + config.location);
+  console.log('Periodic update (30min timer)');
   fetchWeatherForLocation();
+  if (isCustomDataNeeded()) fetchCustomUrl();
 }, 30 * 60 * 1000);
 
 
 // Handle Pebble ready event
 Pebble.addEventListener('ready', function() {
   console.log('PebbleKit JS ready!');
-  console.log('Initial weather fetch for location: "' + config.location + '" (empty = GPS)');
-  //fetchWeatherForLocation();
+  // Push layout/config to watch immediately so panels are correct before data arrives
+  sendDataToPebble();
 });
 
 


### PR DESCRIPTION
Hi, I'm opening this because I like Pebble Mesh, but I wanted to display my own sensor data. It allows displaying custom data fetched from a user-configured HTTPS URL in any of the four watchface info slots.

- Add custom_url.c/h: fetches and renders custom data, with retry handling and a stale-data indicator (red text) when fetch attempts are exhausted.
- Support splitting the custom data into two lines via a '||' separator (large font on top, smaller font below).
- Persist the custom URL and last fetched value across restarts.
- Add Clay settings field for the custom URL with usage instructions.
- Only fetch custom data when the corresponding info slot is actually configured, to avoid unnecessary network requests.

Note that this is mostly AI assisted, especially the C part since I'm not very fluent at it. I've been using it on my own Pebble Time 2 for weeks without issues so I thought I'd share. Since your latest release I had to redo this PR and for some reason my emulator started giving issues, but it should work.

Feel free to review/rewrite/discard this :)